### PR TITLE
Fix typos in Spitzer PSF photometry notebook

### DIFF
--- a/notebooks/PSFPhotometrySpitzer.ipynb
+++ b/notebooks/PSFPhotometrySpitzer.ipynb
@@ -19,7 +19,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The affiliated package *photutils* offers now some basic functions to perform PSF/PRF photometry on astronomical image data. In this notebook I'd like to give a short introduction on the basis of a Spitzer data set. "
+      "The affiliated package *photutils* offers now some basic functions to perform PSF/PRF photometry on astronomical image data. In this notebook I'd like to give a short introduction on the basis of a Spitzer data set."
      ]
     },
     {
@@ -91,7 +91,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "We read the image data using `astropy.io.fits`. As the image data is given in `MJy/sr`, but in the catalog the units are `mJy`, we have to convert the units. Therfore we use that the image data has a resolution of `(1.2 arcsec)^2 / pixel`. Furthermore we set up a mask to exclude NaN values. "
+      "We read the image data using `astropy.io.fits`. As the image data is given in `MJy/sr`, but in the catalog the units are `mJy`, we have to convert the units. Therefore we use that the image data has a resolution of `(1.2 arcsec)^2 / pixel`. Furthermore we set up a mask to exclude NaN values."
      ]
     },
     {
@@ -112,7 +112,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "As the photometry function are currently only able to handle pixel coordinates, we define a WCS transformation to convert the galactic coordinates into pixel coordinates:"
+      "As the photometry function is currently only able to handle pixel coordinates, we define a WCS transformation to convert the galactic coordinates into pixel coordinates:"
      ]
     },
     {
@@ -136,7 +136,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Here is a plot with the source positions overlaied:"
+      "Here is a plot with the source positions overlayed:"
      ]
     },
     {


### PR DESCRIPTION
@adonath Thanks for this!  I have a couple of quick questions.  Where does your comparison catalog come from and how was its photometry generated?  I'm curious because of the apparent coordinate offset that you mention, and also there appears to be less scatter when comparing the catalog to `GaussianPSF` fitting.

Also, when fitting I get many repeated warnings:

```
WARNING: Model is linear in parameters; consider using linear fitting methods. [astropy.modeling.fitting]
```

Presumably this is because you are using the non-linear `LevMarLSQFitter()`.  Can a linear fitter be used instead?  If not, I think we should suppress the warning.
